### PR TITLE
Implement Midi input parent component

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: npm install && npm run build
+    command: npm run start

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,11 @@
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "webmidi": "^3.1.6"
+      },
+      "devDependencies": {
+        "@types/webmidi": "^2.0.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4197,6 +4201,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.5.tgz",
       "integrity": "sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA=="
     },
+    "node_modules/@types/webmidi": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.0.9.tgz",
+      "integrity": "sha512-jQSQw6fkHrF6ODIbRv9COQCgeKG27sGfXvxOgYvSBtXhyLxsT6ybEM1oprskkSbUxtsPtB26Lu38peyrterOqw==",
+      "devOptional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
@@ -6647,6 +6657,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/djipevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/djipevents/-/djipevents-2.0.7.tgz",
+      "integrity": "sha512-KNFYaU85imxOCKOUsIR70Iz9E19r96/X7LSH+u0tSoZdpWcBdzoqtTsU+wuLhc6GMpSFob+KInkZAbfKi01Bjg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/dlv": {
@@ -9717,6 +9735,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jazz-midi": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.9.tgz",
+      "integrity": "sha512-c8c4BBgwxdsIr1iVm53nadCrtH7BUlnX3V95ciK/gbvXN/ndE5+POskBalXgqlc/r9p2XUbdLTrgrC6fou5p9w==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
@@ -11764,6 +11791,16 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jzz": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/jzz/-/jzz-1.7.4.tgz",
+      "integrity": "sha512-Q66OuEauPKImGF/CibsWI/02IEHmoZpAbEq6OcPaz4sihJwmt0J+9gWywudcdD+19cfmekl2I9NsVqlde/Phww==",
+      "optional": true,
+      "dependencies": {
+        "@types/webmidi": "^2.0.9",
+        "jazz-midi": "^1.7.9"
       }
     },
     "node_modules/keyv": {
@@ -16741,6 +16778,20 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
       "engines": {
         "node": ">=10.4"
+      }
+    },
+    "node_modules/webmidi": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-3.1.6.tgz",
+      "integrity": "sha512-IeC7dsm9bupL7Z6PZxVGAbcrguclJ0VAxn3+7UjoZazZWKEwwnq3/ToDbHQdWzOOLwat4fYjp978X1Rd3SQ8Qg==",
+      "dependencies": {
+        "djipevents": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=8.5"
+      },
+      "optionalDependencies": {
+        "jzz": "^1.5.6"
       }
     },
     "node_modules/webpack": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "webmidi": "^3.1.6"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -39,5 +40,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/webmidi": "^2.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "web-vitals": "^2.1.4",
     "webmidi": "^3.1.6"
   },
+  "devDependencies": {
+    "@types/webmidi": "^2.0.9"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
@@ -40,8 +43,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "@types/webmidi": "^2.0.9"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,19 @@
 import React from 'react';
-import logo from './logo.svg';
+
+// import MusicalKeyboardButton from './components/MusicalKeyboardButton';
+import {ConfigEditor} from './components/ConfigEditor';
+
 import './App.css';
-import AssignActions from './components/AssignActions'
-import MusicalKeyboardButton from './components/MusicalKeyboardButton';
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-        <MusicalKeyboardButton />
-        <AssignActions />
-          Learn React
-        </a>
+
+        {/* <MusicalKeyboardButton /> */}
+
+        <ConfigEditor/>
+
       </header>
     </div>
   );

--- a/src/components/AssignActions.tsx
+++ b/src/components/AssignActions.tsx
@@ -1,36 +1,49 @@
 import React, { useState } from 'react';
 
-const AssignActions = () => {
+import {ControlButtonName} from '../types/config-types';
+
+type AssignActionsProps = {
+  selectedControlButton: ControlButtonName | null;
+
+  onClick: (controlButton: ControlButtonName) => void;
+};
+
+const AssignActions = (props: AssignActionsProps) => {
   const [showGrid, setShowGrid] = useState(false);
-  const [selectedButton, setSelectedButton] = useState<string | null>(null);
 
-
-  const handleButtonClick = (buttonId: string) => {
-    setSelectedButton(buttonId);
-    // You can also add logic here to listen to the next midi note, as needed.
-    console.log(`Button ${buttonId} clicked. Awaiting next MIDI input...`);
+  const handleButtonClick = (buttonId: ControlButtonName) => {
+    props.onClick(buttonId);
   };
+
+  if (!showGrid) {
+    return (
+      <div>
+        <button onClick={() => setShowGrid(true)}>Assign Actions</button>
+      </div>
+    );
+  }
+
+  const createSection = (listOfButtons: ControlButtonName[]) => {
+    return (
+      <div>
+        {listOfButtons.map((buttonId) => (
+          <button onClick={() => handleButtonClick(buttonId)}>
+            {buttonId}
+          </button>
+        ))}
+      </div>
+    )
+  };
+
+  const aSection = createSection([ControlButtonName.A1, ControlButtonName.A2, ControlButtonName.A3, ControlButtonName.A4]);
+  const bSection = createSection([ControlButtonName.B1, ControlButtonName.B2, ControlButtonName.B3, ControlButtonName.B4]);
 
   return (
     <div>
-      {!showGrid ? (
-        <button onClick={() => setShowGrid(true)}>Assign Actions</button>
-      ) : (
-        <div>
-          <div>
-            <button onClick={() => handleButtonClick('A1')}>A1</button>
-            <button onClick={() => handleButtonClick('A2')}>A2</button>
-            <button onClick={() => handleButtonClick('A3')}>A3</button>
-            <button onClick={() => handleButtonClick('A4')}>A4</button>
-          </div>
-          <div>
-            <button onClick={() => handleButtonClick('B1')}>B1</button>
-            <button onClick={() => handleButtonClick('B2')}>B2</button>
-            <button onClick={() => handleButtonClick('B3')}>B3</button>
-            <button onClick={() => handleButtonClick('B4')}>B4</button>
-          </div>
-        </div>
-      )}
+      <div>
+        {aSection}
+        {bSection}
+      </div>
     </div>
   );
 };

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,0 +1,72 @@
+import {useEffect, useState} from 'react';
+import {Input as InputDevice, WebMidi} from 'webmidi';
+
+import {mockMidiInputConfig} from '../mockfiles/MockMidiDevice'
+import {Config, MidiInputConfig} from '../types/config-types'
+
+import {MidiInput} from './MidiInput';
+
+const initialConfig: Config = {
+  midi: {
+    inputs: [
+      mockMidiInputConfig,
+    ],
+    outputs: [],
+  }
+}
+
+export const ConfigEditor = () => {
+  const [config, setConfig] = useState<Config>(initialConfig);
+  const [activeInputs, setActiveInputs] = useState<InputDevice[]>([]);
+
+  useEffect(() => {
+    WebMidi.enable({
+      callback: () => {
+        setActiveInputs(WebMidi.inputs);
+      }
+    });
+  }, []);
+
+  const inputConfigs = config.midi.inputs;
+
+  const updateConfigForInputDevice = (inputConfig: MidiInputConfig) => {
+    const index = inputConfigs.findIndex(input => input.name === inputConfig.name);
+    let newConfigState: MidiInputConfig[];
+    if (index === -1) {
+      newConfigState = [...inputConfigs, inputConfig];
+    } else {
+      newConfigState = [...inputConfigs.slice(0, index), inputConfig, ...inputConfigs.slice(index + 1)];
+    }
+
+    setConfig({
+      ...config,
+      midi: {
+        ...config.midi,
+        inputs: newConfigState,
+      },
+    });
+  };
+
+  if (!activeInputs.length) {
+    return (
+      <div>
+        No midi input devices connected
+      </div>
+    )
+  }
+
+  const midiInputs = activeInputs.map((inputDevice: InputDevice) => (
+    <MidiInput
+      key={inputDevice.name}
+      midiInputConfig={inputConfigs.find(input => input.name === inputDevice.name) || null}
+      midiInputDevice={inputDevice}
+      updateInputConfig={updateConfigForInputDevice}
+    />
+  ));
+
+  return (
+    <div>
+      {midiInputs}
+    </div>
+  )
+}

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,51 +1,15 @@
-import {useEffect, useState} from 'react';
-import {Input as InputDevice, WebMidi} from 'webmidi';
+import {Input as InputDevice} from 'webmidi';
 
-import {mockMidiInputConfig} from '../mockfiles/MockMidiDevice'
-import {Config, MidiInputConfig} from '../types/config-types'
+import {useMidi} from '../hooks/useMidi';
 
 import {MidiInput} from './MidiInput';
-
-const initialConfig: Config = {
-  midi: {
-    inputs: [
-      mockMidiInputConfig,
-    ],
-    outputs: [],
-  }
-}
+import {useConfig} from '../hooks/useConfig';
 
 export const ConfigEditor = () => {
-  const [config, setConfig] = useState<Config>(initialConfig);
-  const [activeInputs, setActiveInputs] = useState<InputDevice[]>([]);
-
-  useEffect(() => {
-    WebMidi.enable({
-      callback: () => {
-        setActiveInputs(WebMidi.inputs);
-      }
-    });
-  }, []);
+  const {config, updateConfigForInputDevice} = useConfig();
+  const {activeInputs} = useMidi();
 
   const inputConfigs = config.midi.inputs;
-
-  const updateConfigForInputDevice = (inputConfig: MidiInputConfig) => {
-    const index = inputConfigs.findIndex(input => input.name === inputConfig.name);
-    let newConfigState: MidiInputConfig[];
-    if (index === -1) {
-      newConfigState = [...inputConfigs, inputConfig];
-    } else {
-      newConfigState = [...inputConfigs.slice(0, index), inputConfig, ...inputConfigs.slice(index + 1)];
-    }
-
-    setConfig({
-      ...config,
-      midi: {
-        ...config.midi,
-        inputs: newConfigState,
-      },
-    });
-  };
 
   if (!activeInputs.length) {
     return (

--- a/src/components/MidiInput.tsx
+++ b/src/components/MidiInput.tsx
@@ -61,9 +61,21 @@ export const MidiInput = (props: MidiInputProps) => {
   return (
     <div className='midi-input-container'>
       <h2>{props.midiInputDevice.name}</h2>
-      <pre>
-        {JSON.stringify(state, null, 2)}
-      </pre>
+
+      <div>
+        Config:
+        <pre>
+          {JSON.stringify(props.midiInputConfig, null, 2)}
+        </pre>
+      </div>
+
+      <div>
+        State:
+        <pre>
+          {JSON.stringify(state, null, 2)}
+        </pre>
+      </div>
+
       <div>
         <button onClick={() => handleClick(ConfigButton.MUSICAL_KEYBOARD)}>
           Musical Keyboard

--- a/src/components/MidiInput.tsx
+++ b/src/components/MidiInput.tsx
@@ -1,0 +1,91 @@
+import {useState} from 'react';
+
+import {Input as InputDevice} from 'webmidi'
+
+import {ControlButtonName, MidiInputConfig} from '../types/config-types';
+import AssignActions from './AssignActions';
+
+enum ConfigButton {
+  MUSICAL_KEYBOARD = 'musicalKeyboard',
+  MAIN_TRIGGER = 'mainTrigger',
+  CONTROL_BUTTONS = 'controlButtons'
+}
+
+type MidiInputProps = {
+  midiInputConfig: MidiInputConfig | null;
+  midiInputDevice: InputDevice;
+
+  updateInputConfig: (inputConfig: MidiInputConfig) => void;
+}
+
+type MidiInputState = {
+  selectedButton: ConfigButton | null;
+  selectedControlButton: ControlButtonName | null;
+}
+
+export const MidiInput = (props: MidiInputProps) => {
+  const [state, setState] = useState<MidiInputState>({
+    selectedButton: null,
+    selectedControlButton: null,
+  });
+
+  const handleClick = (button: ConfigButton) => {
+    setState({
+      selectedButton: button,
+      selectedControlButton: null,
+    });
+  };
+
+  const handleClickControlMapButton = (controlButton: ControlButtonName) => {
+    setState({
+      selectedButton: ConfigButton.CONTROL_BUTTONS,
+      selectedControlButton: controlButton,
+    });
+  };
+
+  if (!props.midiInputConfig) {
+    return (
+      <div className='midi-input-container'>
+        <h2>{props.midiInputDevice.name}</h2>
+        <button onClick={() => {
+          props.updateInputConfig({
+            name: props.midiInputDevice.name,
+          })
+        }}>
+          Configure
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className='midi-input-container'>
+      <h2>{props.midiInputDevice.name}</h2>
+      <pre>
+        {JSON.stringify(state, null, 2)}
+      </pre>
+      <div>
+        <button onClick={() => handleClick(ConfigButton.MUSICAL_KEYBOARD)}>
+          Musical Keyboard
+        </button>
+        <pre>
+          {JSON.stringify(props.midiInputConfig.musicalKeyboard)}
+        </pre>
+      </div>
+
+      <div>
+        <button onClick={() => handleClick(ConfigButton.MAIN_TRIGGER)}>
+          Main Trigger
+        </button>
+        <pre>
+          {JSON.stringify(props.midiInputConfig.mainTrigger)}
+        </pre>
+      </div>
+
+      <AssignActions
+        selectedControlButton={state.selectedControlButton}
+        onClick={handleClickControlMapButton}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,0 +1,50 @@
+import {useState} from 'react';
+
+import {Config, MidiInputConfig} from '../types/config-types';
+import {mockMidiInputConfig} from '../mockfiles/MockMidiDevice';
+
+export type UseConfigHookValue = {
+  config: Config;
+
+  setConfig: (config: Config) => void;
+  updateConfigForInputDevice: (inputConfig: MidiInputConfig) => void;
+}
+
+const initialConfig: Config = {
+  midi: {
+    inputs: [
+      mockMidiInputConfig,
+    ],
+    outputs: [],
+  }
+}
+
+export const useConfig = (): UseConfigHookValue => {
+  const [config, setConfig] = useState<Config>(initialConfig);
+
+  const updateConfigForInputDevice = (inputConfig: MidiInputConfig) => {
+    const inputConfigs = config.midi.inputs;
+
+    const index = inputConfigs.findIndex(input => input.name === inputConfig.name);
+    let newConfigState: MidiInputConfig[];
+    if (index === -1) {
+      newConfigState = [...inputConfigs, inputConfig];
+    } else {
+      newConfigState = [...inputConfigs.slice(0, index), inputConfig, ...inputConfigs.slice(index + 1)];
+    }
+
+    setConfig({
+      ...config,
+      midi: {
+        ...config.midi,
+        inputs: newConfigState,
+      },
+    });
+  };
+
+  return {
+    config,
+    setConfig,
+    updateConfigForInputDevice,
+  };
+};

--- a/src/hooks/useMidi.ts
+++ b/src/hooks/useMidi.ts
@@ -1,0 +1,22 @@
+import {useEffect, useState} from 'react';
+import {Input as InputDevice, WebMidi} from 'webmidi';
+
+export type UseMidiHookValue = {
+    activeInputs: InputDevice[];
+}
+
+export const useMidi = (): UseMidiHookValue => {
+    const [activeInputs, setActiveInputs] = useState<InputDevice[]>([]);
+
+    useEffect(() => {
+      WebMidi.enable({
+        callback: () => {
+          setActiveInputs(WebMidi.inputs);
+        }
+      });
+    }, []);
+
+    return {
+        activeInputs,
+    };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,14 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.midi-input-container {
+  border: 1px solid;
+  margin: 20px;
+  padding: 20px;
+}
+
+pre {
+  font-size: 10px;
+  text-align: left;
+}


### PR DESCRIPTION
This PR makes it so we show connected midi devices, using the [webmidi](https://github.com/djipco/webmidi) npm package. Clicking on the Configure button shows the config form for that input device.

Known remaining tasks:

- Listen for midi note presses on the `inputDevice` object, and use that to set config values
- Persist/load config with localStorage or HTTP API
- Display "configured but not connected" devices. Probably emphasize "connected configured" ones over "connected not configured" ones as well.

<img width="600px" src="https://github.com/aelishRollo/midi-config/assets/6913320/1b936d6a-3726-448d-aa66-16274a65ad9f"/>